### PR TITLE
Feat update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "wheel",
         "requests",
         "setuptools>57.5.0" 'importlib; python_version == "3.7"',
-        "vamb @ git+git://github.com/AndreLamurias/vamb",
+        "vamb @ git+https://github.com/AndreLamurias/vamb",
         "networkx==2.6.2",
         # torch==1.7.1
         "scikit-learn==0.24.2",


### PR DESCRIPTION
Replace `git+git` on `git+https` in line 22 as recent GiuHub updates require this for anonymous cloning - it makes installation Option 2 - "From source" - working correctly and installes everything
